### PR TITLE
Removes one of the nested arrays it was added by mistake

### DIFF
--- a/routes/api.js
+++ b/routes/api.js
@@ -96,10 +96,7 @@ router.get('/:netName?/price/:requestID/:count?', async function (req, res) {
 			value: value,
 		})
 	}
-
-	res.send([
-		results,
-	])
+	res.send(results)
 })
 
 //Get data for a specific dispute


### PR DESCRIPTION
```
[[{"timestamp":"1605668100","value":"1041364"}]]
changed to 
[{"timestamp":"1605668100","value":"1041364"}]
```


Note the double brackets.